### PR TITLE
simplify hooks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,9 @@
 - Absurd SQL debug extension (e.g., inspect tables)
 
 # API Problems
+- just basic `update`, `create` and `delete` to not require mutations defined on schema
+- `update` / etc. can have `cs` variants that return a cs rather than immediately saving
+- `cs` and `optimistic` variants so you don't have to deal with a returned tuple
 - Enable sets (not just maps or arrays)
 - readonly enumerations of arrays...
 - Using mutations within mutations and gathering all changesets together while still allowing chaining

--- a/examples/todo-mvc-mem/package.json
+++ b/examples/todo-mvc-mem/package.json
@@ -11,13 +11,13 @@
     "ts-build": "tsc"
   },
   "dependencies": {
-    "@aphro/react": "^0.1.10",
-    "@aphro/runtime-ts": "^0.1.9",
+    "@aphro/react": "workspace:*",
+    "@aphro/runtime-ts": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@aphro/codegen-cli": "^0.1.10",
+    "@aphro/codegen-cli": "workspace:*",
     "@types/react": "^18.0.14",
     "html-webpack-plugin": "^5.5.0",
     "raw-loader": "^4.0.2",
@@ -28,5 +28,5 @@
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.9.2"
   },
-  "version": null
+  "version": "0.0.1"
 }

--- a/examples/todo-mvc-mem/src/App.tsx
+++ b/examples/todo-mvc-mem/src/App.tsx
@@ -186,11 +186,11 @@ export default function App({ list }: { list: TodoList }) {
   let toggleAllCheck;
 
   useBind(list, ['filter', 'editing']);
-  const [activeTodos, completeTodos, allTodos] = unwraps(
-    useQuery(UpdateType.ANY, () => list.queryTodos().whereCompleted(P.equals(false)), []),
-    useQuery(UpdateType.ANY, () => list.queryTodos().whereCompleted(P.equals(true)), []),
-    useQuery(UpdateType.CREATE_OR_DELETE, () => list.queryTodos(), []),
-  );
+  const [activeTodos, completeTodos, allTodos] = [
+    useQuery(() => list.queryTodos().whereCompleted(P.equals(false)), []),
+    useQuery(() => list.queryTodos().whereCompleted(P.equals(true)), []),
+    useQuery(() => list.queryTodos(), [], UpdateType.CREATE_OR_DELETE),
+  ];
 
   const remaining = activeTodos.length;
   let todos =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,9 @@ importers:
 
   examples/todo-mvc-mem:
     specifiers:
-      '@aphro/codegen-cli': ^0.1.7
-      '@aphro/react': ^0.1.9
-      '@aphro/runtime-ts': ^0.1.7
+      '@aphro/codegen-cli': workspace:*
+      '@aphro/react': workspace:*
+      '@aphro/runtime-ts': workspace:*
       '@types/react': ^18.0.14
       html-webpack-plugin: ^5.5.0
       raw-loader: ^4.0.2


### PR DESCRIPTION
- no need to `unwrap` anymore
- potential support for suspense

cc @a-type

This is based on our discussion in discord.

Rather than doing:
```js
unwraps(
    useQuery(UpdateType.ANY, () => list.queryTodos().whereCompleted(P.equals(false)), [])
)
```

You can now just do:
```js
useQuery(() => list.queryTodos().whereCompleted(P.equals(false)), [])
```

I also added a `useQuerySuspense` -- it isn't suspense ready yet given the thrown exception is the incorrect format. Will make it suspense friendly after gathering feedback.