### PR TITLE
add missing dependency

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,6 +25,7 @@
     "@aphro/runtime-ts": "workspace:*",
     "@typescript-eslint/typescript-estree": "^5.22.0",
     "jest": "^28.1.0",
+    "react": "^18.0.0",
     "ts-jest": "^28.0.1",
     "typescript": "^4.6.4"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,7 +9,8 @@
     "directory": "packages/react"
   },
   "dependencies": {
-    "@strut/counter": "^0.0.11"
+    "@strut/counter": "^0.0.11",
+    "suspend-react": "^0.0.8"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -731,10 +731,12 @@ importers:
       '@types/react': ^18.0.10
       '@typescript-eslint/typescript-estree': ^5.22.0
       jest: ^28.1.0
+      suspend-react: ^0.0.8
       ts-jest: ^28.0.1
       typescript: ^4.6.4
     dependencies:
       '@strut/counter': 0.0.11
+      suspend-react: 0.0.8
     devDependencies:
       '@aphro/codegen-cli': link:../codegen-cli
       '@aphro/runtime-ts': link:../runtime-ts
@@ -9434,6 +9436,12 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /suspend-react/0.0.8:
+    resolution: {integrity: sha512-ZC3r8Hu1y0dIThzsGw0RLZplnX9yXwfItcvaIzJc2VQVi8TGyGDlu92syMB5ulybfvGLHAI5Ghzlk23UBPF8xg==}
+    peerDependencies:
+      react: '>=17.0'
+    dev: false
+
   /suspend-react/0.0.8_react@18.2.0:
     resolution: {integrity: sha512-ZC3r8Hu1y0dIThzsGw0RLZplnX9yXwfItcvaIzJc2VQVi8TGyGDlu92syMB5ulybfvGLHAI5Ghzlk23UBPF8xg==}
     peerDependencies:
@@ -9613,7 +9621,7 @@ packages:
       '@babel/core': 7.18.9
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 28.1.0_@types+node@17.0.31
+      jest: 28.1.0
       jest-util: 28.1.0
       json5: 2.2.1
       lodash.memoize: 4.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -731,12 +731,13 @@ importers:
       '@types/react': ^18.0.10
       '@typescript-eslint/typescript-estree': ^5.22.0
       jest: ^28.1.0
+      react: ^18.0.0
       suspend-react: ^0.0.8
       ts-jest: ^28.0.1
       typescript: ^4.6.4
     dependencies:
       '@strut/counter': 0.0.11
-      suspend-react: 0.0.8
+      suspend-react: 0.0.8_react@18.2.0
     devDependencies:
       '@aphro/codegen-cli': link:../codegen-cli
       '@aphro/runtime-ts': link:../runtime-ts
@@ -746,6 +747,7 @@ importers:
       '@types/react': 18.0.17
       '@typescript-eslint/typescript-estree': 5.33.0_typescript@4.7.2
       jest: 28.1.0
+      react: 18.2.0
       ts-jest: 28.0.4_hkzrkv5hmwhzxrddi5ta6hqdsy
       typescript: 4.7.2
 
@@ -7768,7 +7770,6 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-    dev: false
 
   /lower-case/2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
@@ -8687,7 +8688,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-    dev: false
 
   /read-pkg-up/7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -9435,12 +9435,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
     dev: true
-
-  /suspend-react/0.0.8:
-    resolution: {integrity: sha512-ZC3r8Hu1y0dIThzsGw0RLZplnX9yXwfItcvaIzJc2VQVi8TGyGDlu92syMB5ulybfvGLHAI5Ghzlk23UBPF8xg==}
-    peerDependencies:
-      react: '>=17.0'
-    dev: false
 
   /suspend-react/0.0.8_react@18.2.0:
     resolution: {integrity: sha512-ZC3r8Hu1y0dIThzsGw0RLZplnX9yXwfItcvaIzJc2VQVi8TGyGDlu92syMB5ulybfvGLHAI5Ghzlk23UBPF8xg==}


### PR DESCRIPTION
Not sure how this didn't get added to the deps list. I think I'm just not familiar enough with pnpm.

Also, it complains that `suspend-react`'s peer dep for `react` is not fulfilled... but the library itself specifies `react` as a peer dep. I added it as a dev dependency, that's usually how I do peer deps for libraries anyway. That makes pnpm happy at least.